### PR TITLE
fix: update mobile viewport preset to 430x932 for iPhone 15/16

### DIFF
--- a/.changeset/update-mobile-viewport.md
+++ b/.changeset/update-mobile-viewport.md
@@ -1,0 +1,5 @@
+---
+'heroshot': patch
+---
+
+Update mobile viewport preset from 375x667 to 430x932 to support modern iPhone 15/16 devices

--- a/integrations/python/heroshot/mkdocs.py
+++ b/integrations/python/heroshot/mkdocs.py
@@ -25,7 +25,7 @@ from typing import List, Optional
 
 # Viewport width mapping for media queries
 VIEWPORT_WIDTHS = {
-    "mobile": 375,
+    "mobile": 430,  # iPhone 15/16 Pro Max viewport
     "tablet": 768,
     "desktop": 1280,
 }

--- a/integrations/python/heroshot/sphinx.py
+++ b/integrations/python/heroshot/sphinx.py
@@ -39,7 +39,7 @@ from sphinx.util.docutils import SphinxDirective
 
 # Viewport width mapping for media queries
 VIEWPORT_WIDTHS = {
-    "mobile": 375,
+    "mobile": 430,  # iPhone 15/16 Pro Max viewport
     "tablet": 768,
     "desktop": 1280,
 }

--- a/integrations/react/src/components/Heroshot.tsx
+++ b/integrations/react/src/components/Heroshot.tsx
@@ -135,7 +135,7 @@ function useIsDark(): boolean {
 
 /** Viewport width mapping */
 const VIEWPORT_WIDTHS: Record<string, number> = {
-  mobile: 375,
+  mobile: 430, // iPhone 15/16 Pro Max viewport
   tablet: 768,
   desktop: 1280,
 };

--- a/integrations/vue/src/components/Heroshot.vue
+++ b/integrations/vue/src/components/Heroshot.vue
@@ -119,7 +119,7 @@ const themeSrc = computed(() => {
 
 // Viewport width mapping for media queries
 const VIEWPORT_WIDTHS: Record<string, number> = {
-  mobile: 375,
+  mobile: 430, // iPhone 15/16 Pro Max viewport
   tablet: 768,
   desktop: 1280,
 };

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -58,7 +58,7 @@ program
   .option('-p, --padding <pixels>', 'Padding around element', Number.parseInt)
   .option('-w, --width <pixels>', 'Viewport width', Number.parseInt)
   .option('--height <pixels>', 'Viewport height', Number.parseInt)
-  .option('--mobile', 'Use mobile viewport (375x667)')
+  .option('--mobile', 'Use mobile viewport (430x932)')
   .option('--tablet', 'Use tablet viewport (768x1024)')
   .option('--desktop', 'Use desktop viewport (1280x800)')
   .option('--dark', 'Force dark color scheme')

--- a/src/cli/tests/buildShotConfig.test.ts
+++ b/src/cli/tests/buildShotConfig.test.ts
@@ -58,7 +58,7 @@ describe('buildShotConfig', () => {
 
   it('uses viewport from options', () => {
     const result = buildShotConfig('https://example.com', { mobile: true }, undefined);
-    expect(result.browser?.viewport).toEqual({ width: 375, height: 667 });
+    expect(result.browser?.viewport).toEqual({ width: 430, height: 932 });
   });
 
   it('uses viewport from existing config', () => {

--- a/src/cli/tests/optionsParsers.test.ts
+++ b/src/cli/tests/optionsParsers.test.ts
@@ -79,7 +79,7 @@ describe('getDeviceScaleFactor', () => {
 describe('getViewport', () => {
   it('returns mobile preset', () => {
     const result = getViewport({ mobile: true }, undefined);
-    expect(result).toEqual({ width: 375, height: 667 });
+    expect(result).toEqual({ width: 430, height: 932 });
   });
 
   it('returns tablet preset', () => {
@@ -135,6 +135,6 @@ describe('getViewport', () => {
 
   it('prefers preset over custom dimensions', () => {
     const result = getViewport({ mobile: true, width: 1920 }, undefined);
-    expect(result).toEqual({ width: 375, height: 667 });
+    expect(result).toEqual({ width: 430, height: 932 });
   });
 });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,7 +16,7 @@ export type ViewportPreset = 'desktop' | 'tablet' | 'mobile';
 export const VIEWPORT_PRESETS: Record<ViewportPreset, { width: number; height: number }> = {
   desktop: { width: 1280, height: 800 },
   tablet: { width: 768, height: 1024 },
-  mobile: { width: 375, height: 667 },
+  mobile: { width: 430, height: 932 }, // iPhone 15/16 Pro Max viewport
 };
 
 /** Browser viewport settings */
@@ -150,7 +150,7 @@ const shotCliOptionsSchema = z.object({
   width: z.number().int().positive().optional(),
   /** Viewport height */
   height: z.number().int().positive().optional(),
-  /** Use mobile viewport preset (375x667) */
+  /** Use mobile viewport preset (430x932) */
   mobile: z.boolean().optional(),
   /** Use tablet viewport preset (768x1024) */
   tablet: z.boolean().optional(),

--- a/src/sync/tests/parallelCapture.test.ts
+++ b/src/sync/tests/parallelCapture.test.ts
@@ -120,7 +120,7 @@ describe('buildCaptureJobs', () => {
       expect(jobs[1]).toMatchObject({
         screenshot: screenshots[0],
         colorScheme: undefined,
-        viewport: { name: 'mobile', width: 375, height: 667 },
+        viewport: { name: 'mobile', width: 430, height: 932 },
         hasMultipleViewports: true,
       });
     });

--- a/src/tests/cli/cli.test.ts
+++ b/src/tests/cli/cli.test.ts
@@ -83,9 +83,9 @@ describe.concurrent('CLI URL capture', () => {
       expect(existsSync(outputPath)).toBe(true);
 
       const dimensions = await getImageDimensions(outputPath);
-      // Mobile viewport is 375, but scrollbar width varies by platform
-      expect(dimensions.width).toBeGreaterThanOrEqual(375);
-      expect(dimensions.width).toBeLessThan(420);
+      // Mobile viewport is 430, but scrollbar width varies by platform
+      expect(dimensions.width).toBeGreaterThanOrEqual(430);
+      expect(dimensions.width).toBeLessThan(475);
     }, 60_000);
 
     it('captures with custom dimensions', async () => {
@@ -153,9 +153,9 @@ describe.concurrent('CLI URL capture', () => {
       expect(existsSync(outputPath)).toBe(true);
 
       const dimensions = await getImageDimensions(outputPath);
-      // Mobile (375) at 2x = 750, but scrollbar width varies by platform
-      expect(dimensions.width).toBeGreaterThanOrEqual(750);
-      expect(dimensions.width).toBeLessThan(840);
+      // Mobile (430) at 2x = 860, but scrollbar width varies by platform
+      expect(dimensions.width).toBeGreaterThanOrEqual(860);
+      expect(dimensions.width).toBeLessThan(950);
     }, 60_000);
   });
 
@@ -250,9 +250,9 @@ describe.concurrent('CLI URL capture', () => {
       expect(existsSync(outputPath)).toBe(true);
 
       const dimensions = await getImageDimensions(outputPath);
-      // Mobile (375) at 1x
-      expect(dimensions.width).toBeGreaterThanOrEqual(375);
-      expect(dimensions.width).toBeLessThan(420);
+      // Mobile (430) at 1x
+      expect(dimensions.width).toBeGreaterThanOrEqual(430);
+      expect(dimensions.width).toBeLessThan(475);
     }, 60_000);
 
     it('captures with --scale 3 (high DPI)', async () => {
@@ -265,9 +265,9 @@ describe.concurrent('CLI URL capture', () => {
       expect(existsSync(outputPath)).toBe(true);
 
       const dimensions = await getImageDimensions(outputPath);
-      // Mobile (375) at 3x = 1125
-      expect(dimensions.width).toBeGreaterThanOrEqual(1125);
-      expect(dimensions.width).toBeLessThan(1260);
+      // Mobile (430) at 3x = 1290
+      expect(dimensions.width).toBeGreaterThanOrEqual(1290);
+      expect(dimensions.width).toBeLessThan(1425);
     }, 60_000);
   });
 
@@ -351,7 +351,7 @@ describe.concurrent('CLI URL capture', () => {
 
       // Element should be captured with padding on mobile viewport
       const dimensions = await getImageDimensions(outputPath);
-      expect(dimensions.width).toBeLessThanOrEqual(395); // 375 + 20 padding
+      expect(dimensions.width).toBeLessThanOrEqual(450); // 430 + 20 padding
     }, 60_000);
 
     it('combines viewport-only + custom dimensions', async () => {

--- a/src/utils/tests/parseViewport.test.ts
+++ b/src/utils/tests/parseViewport.test.ts
@@ -21,8 +21,8 @@ describe('parseViewport', () => {
   it('parses mobile preset', () => {
     expect(parseViewport('mobile')).toEqual({
       name: 'mobile',
-      width: 375,
-      height: 667,
+      width: 430,
+      height: 932,
     });
   });
 


### PR DESCRIPTION
## Summary
- Updates mobile viewport preset from 375x667 to 430x932 to support modern iPhone 15/16 devices
- iPhone 15/16 Pro Max has 430px CSS viewport width, previous 375px was for older iPhone SE/6/7/8

## Changes
- Core preset in `src/schema.ts`
- Vue component media query breakpoint
- React component media query breakpoint
- Python integrations (MkDocs, Sphinx)
- CLI help text
- All related tests

## Note
After release, the hero screenshot on heroshot.sh needs to be re-captured with the new mobile viewport size so the media query `(max-width: 430px)` correctly serves the mobile image on modern iPhones.